### PR TITLE
Compact slices when adding many duplicate names

### DIFF
--- a/entry_test.go
+++ b/entry_test.go
@@ -32,6 +32,24 @@ func TestEntry_WithFields(t *testing.T) {
 	qt.Assert(t, time.Now().IsZero(), qt.IsFalse)
 }
 
+func TestEntry_WithManyFieldsWithSameName(t *testing.T) {
+	h := memory.New()
+	a := logg.NewLogger(logg.LoggerConfig{Handler: h, Level: logg.LevelInfo}).WithLevel(logg.LevelInfo)
+
+	b := a.WithFields(logg.Fields{{"foo", "bar"}})
+
+	for i := 0; i < 100; i++ {
+		b = b.WithFields(logg.Fields{{"foo", "bar"}})
+	}
+
+	b.Log(logg.String("upload"))
+	e := h.Entries[0]
+
+	qt.Assert(t, "upload", qt.Equals, e.Message)
+	qt.Assert(t, logg.Fields{{"foo", "bar"}}, qt.DeepEquals, e.Fields)
+
+}
+
 func TestEntry_WithField(t *testing.T) {
 	h := memory.New()
 	a := logg.NewLogger(logg.LoggerConfig{Handler: h, Level: logg.LevelInfo}).WithLevel(logg.LevelInfo)

--- a/logger_test.go
+++ b/logger_test.go
@@ -154,6 +154,32 @@ func BenchmarkLogger_common_context_many_fields(b *testing.B) {
 	}
 }
 
+func BenchmarkLogger_context_many_fields_duplicate_names_with_field(b *testing.B) {
+	l := logg.NewLogger(logg.LoggerConfig{Level: logg.LevelInfo, Handler: handlers.Discard})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		info := l.WithLevel(logg.LevelInfo)
+		for i := 0; i < 9999; i++ {
+			info = info.WithField("name", "value")
+		}
+		info.Log(logg.String("upload"))
+	}
+}
+
+func BenchmarkLogger_context_many_fields_duplicate_names_with_fields(b *testing.B) {
+	l := logg.NewLogger(logg.LoggerConfig{Level: logg.LevelInfo, Handler: handlers.Discard})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		info := l.WithLevel(logg.LevelInfo)
+		for i := 0; i < 3333; i++ {
+			info = info.WithFields(logg.Fields{{"name", "value"}, {"name", "value"}, {"name", "value"}})
+		}
+		info.Log(logg.String("upload"))
+	}
+}
+
 func BenchmarkLogger_levels(b *testing.B) {
 	doWork := func(l logg.LevelLogger) {
 		for i := 0; i < 10; i++ {


### PR DESCRIPTION
Also, simplifying the merge logic.

Handling this case:

```go
info := l.WithLevel(logg.LevelInfo)
for i := 0; i < 99999999; i++ {
    info = info.WithField("name", "value")
}
```

Which is not the right way to use this API, but probably common enough a case to add a check for.

```bash
name                                                       old time/op    new time/op    delta
Logger_context_many_fields_duplicate_names_with_field-10      995µs ± 1%     859µs ± 0%  -13.62%  (p=0.029 n=4+4)
Logger_context_many_fields_duplicate_names_with_fields-10     509µs ± 2%     331µs ± 0%  -35.07%  (p=0.029 n=4+4)

name                                                       old alloc/op   new alloc/op   delta
Logger_context_many_fields_duplicate_names_with_field-10     2.67MB ± 0%    1.53MB ± 0%  -42.84%  (p=0.029 n=4+4)
Logger_context_many_fields_duplicate_names_with_fields-10    1.97MB ± 0%    0.73MB ± 0%  -62.76%  (p=0.029 n=4+4)

name                                                       old allocs/op  new allocs/op  delta
Logger_context_many_fields_duplicate_names_with_field-10      30.0k ± 0%     30.0k ± 0%   -0.04%  (p=0.029 n=4+4)
Logger_context_many_fields_duplicate_names_with_fields-10     10.0k ± 0%     10.0k ± 0%   -0.12%  (p=0.029 n=4+4)
```