### PR TITLE
Fix benchmarks by matching recent code changes

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -1,4 +1,4 @@
-module github.com/bep/log/benchmarks
+module github.com/bep/logg/benchmarks
 
 go 1.18
 

--- a/benchmarks/logn_test.go
+++ b/benchmarks/logn_test.go
@@ -28,20 +28,20 @@ import (
 )
 
 func newDisabledLoggLog() logg.LevelLogger {
-	logger := logg.NewLogger(logg.LoggerConfig{
+	logger := logg.New(logg.Options{
 		Handler: json.New(io.Discard),
-		Level:   logg.ErrorLevel,
+		Level:   logg.LevelError,
 	})
-	return logger.WithLevel(logg.InfoLevel)
+	return logger.WithLevel(logg.LevelInfo)
 }
 
 func newLoggLog() logg.LevelLogger {
-	logger := logg.NewLogger(logg.LoggerConfig{
+	logger := logg.New(logg.Options{
 		Handler: json.New(io.Discard),
-		Level:   logg.DebugLevel,
+		Level:   logg.LevelDebug,
 	})
 
-	return logger.WithLevel(logg.DebugLevel)
+	return logger.WithLevel(logg.LevelDebug)
 }
 
 func fakeLognFields() logg.FieldsFunc {

--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkDisabledWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				message := logg.NewStringFunc(func() string { return getMessage(0) })
+				message := logg.StringFunc(func() string { return getMessage(0) })
 				logger.Log(message)
 			}
 		})
@@ -85,7 +85,7 @@ func BenchmarkDisabledAccumulatedContext(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				message := logg.NewStringFunc(func() string { return getMessage(0) })
+				message := logg.StringFunc(func() string { return getMessage(0) })
 				logger.Log(message)
 			}
 		})
@@ -126,7 +126,7 @@ func BenchmarkDisabledAddingFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				message := logg.NewStringFunc(func() string { return getMessage(0) })
+				message := logg.StringFunc(func() string { return getMessage(0) })
 				logger.WithFields(fakeLognFields()).Log(message)
 			}
 		})
@@ -167,7 +167,7 @@ func BenchmarkWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				message := logg.NewStringFunc(func() string { return getMessage(0) })
+				message := logg.StringFunc(func() string { return getMessage(0) })
 				logger.Log(message)
 			}
 		})
@@ -264,7 +264,7 @@ func BenchmarkAccumulatedContext(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				message := logg.NewStringFunc(func() string { return getMessage(0) })
+				message := logg.StringFunc(func() string { return getMessage(0) })
 				logger.Log(message)
 			}
 		})
@@ -343,7 +343,7 @@ func BenchmarkAddingFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				message := logg.NewStringFunc(func() string { return getMessage(0) })
+				message := logg.StringFunc(func() string { return getMessage(0) })
 				logger.WithFields(fakeLognFields()).Log(message)
 			}
 		})


### PR DESCRIPTION
Hi @bep, I am incorporating the benchmark tests as part of the Debian package build and autopkgtest, and needed these minor changes to get the benchmarks to run.  Thanks!