### PR TITLE
ci: Fix cache warnings by moving checkout step first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Install Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
@@ -21,8 +23,6 @@ jobs:
     - name: Update PATH
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       shell: bash
-    - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Fmt
       if: matrix.platform != 'windows-latest' # :(
       run: "diff <(gofmt -d .) <(printf '')"


### PR DESCRIPTION
## Summary
- Move checkout step to be the first step in the workflow to fix "Restore cache failed" warnings
- The warning occurs because setup-go tries to cache Go modules before the source is checked out

## Test plan
- [ ] Verify the CI workflow runs without cache warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)